### PR TITLE
Bump version number for PyPI release

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -4,6 +4,6 @@
   "download_url": "",
   "author": "RTI International",
   "maintainer": "Jason Nance",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Uniform interface to deep learning approaches via Docker containers."
 }


### PR DESCRIPTION
## Description of Changes

Bump version number for release v0.2.2 -- forgot to include this in the release.
