### PR TITLE
Fix Unix-specific code to get directory creation time

### DIFF
--- a/gobbli/interactive/util.py
+++ b/gobbli/interactive/util.py
@@ -325,7 +325,13 @@ def format_task(task_dir: Path) -> str:
       String-formatted, human-readable task metadata.
     """
     task_id = task_dir.name
-    task_creation_time = dt.datetime.fromtimestamp(task_dir.stat().st_birthtime)
+    try:
+        # Should work on OS X, Linux
+        task_creation_ts = task_dir.stat().st_birthtime
+    except AttributeError:
+        # Should work on Windows
+        task_creation_ts = task_dir.stat().st_ctime
+    task_creation_time = dt.datetime.fromtimestamp(task_creation_ts)
     return f"{task_id[:5]} - Created {task_creation_time.strftime('%Y-%m-%d %H:%M:%S')}"
 
 

--- a/meta.json
+++ b/meta.json
@@ -4,6 +4,6 @@
   "download_url": "",
   "author": "RTI International",
   "maintainer": "Jason Nance",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Uniform interface to deep learning approaches via Docker containers."
 }


### PR DESCRIPTION
## Description of Changes

Fix a platform-specific method for getting file creation time.

## Related Issue(s), if any

#25 
